### PR TITLE
Add error handling so link in no results goes back to search

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,9 @@ function App() {
               setBeers={setBeers}
               setAddress={setAddress}
               setName={setName}
+              setLocation={setLocation}
+              setRadius={setRadius}
+              setStyle={setStyle}
             />
           )}
         />

--- a/src/components/AboutUs/AboutUs.css
+++ b/src/components/AboutUs/AboutUs.css
@@ -26,8 +26,8 @@
   width: 75%;
   font-size: 2em;
   transform: translateY(-128%);
-  color: #fff897;
-  text-shadow: 0 8px 2px black;
+  color: white;
+  text-shadow: 0 4px 4px black;
 }
 
 .developers {

--- a/src/components/BreweriesContainer/BreweriesContainer.css
+++ b/src/components/BreweriesContainer/BreweriesContainer.css
@@ -14,12 +14,19 @@
 }
 
 .loading-message {
-  font-size: 1.75em;
+  font-size: 2em;
   text-shadow: 0 5px 5px #fff897;
+  color: black;
+  text-decoration: none;
   font-weight: bold;
   width: 90%;
   transform: translateY(8.75em);
   margin: 0;
+}
+
+a {
+  color: black;
+  text-decoration: none;
 }
 
 .singles::-webkit-scrollbar {

--- a/src/components/BreweriesContainer/BreweriesContainer.js
+++ b/src/components/BreweriesContainer/BreweriesContainer.js
@@ -3,6 +3,7 @@ import bar from "../../assets/bar.jpg";
 import SingleBrewery from "../SingleBrewery/SingleBrewery";
 import Loading from "../Loading/Loading";
 import { useQuery, gql } from "@apollo/client";
+import { Link } from "react-router-dom"
 
 const BreweriesContainer = ({
   location,
@@ -11,9 +12,18 @@ const BreweriesContainer = ({
   setBeers,
   setAddress,
   setName,
+  setLocation,
+  setRadius,
+  setStyle
 }) => {
   let selectedBreweries;
   let noResults;
+
+  const handleClick = () => {
+    setLocation("");
+    setRadius("");
+    setStyle("");
+  };
 
   const GET_BREWERIES = gql`
     query breweries($location: String!, $radius: String!, $style: String!) {
@@ -71,7 +81,7 @@ const BreweriesContainer = ({
   }
 
   if (!loading && data.breweries.length === 0) {
-    noResults = `No results matched your search! Click the MaltFinder icon and search again.`;
+    noResults = `No results matched your search! Click this and search again.`;
   }
 
   return (
@@ -80,7 +90,7 @@ const BreweriesContainer = ({
         <img src={bar} className="bars-image" alt="bar" />
         <div className="singles">
           {selectedBreweries ? selectedBreweries : <Loading />}
-          {noResults && <p className="loading-message">{noResults}</p>}
+          {noResults && <Link to='/maltfinder'><p className="loading-message" onClick={() => handleClick()}>{noResults}</p></Link> }
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Problem/feature

_What problem are you trying to solve?_

There wasn't a clean way to go back to the maltfinder search page without first navigating home.

## Solution

_How did you solve the problem?_

We changed the P tag in the error message for no results to be a link that returns to the maltfinder form. We also updated the text color in the about me section to be white so that it is more readable.

## Other changes (e.g. bug fixes, UI tweaks, small refactors)

## Checklist
- [x] Code compiles correctly
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary